### PR TITLE
chore(tokens): add tokens.css, package.json, and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,56 @@
-# nextchapter-design-tokens
-Shared Tailwind tokens config for consistent design system application across the `nextchapter` and `nextchapter-mobile` projects.
+# @stevebutler2210/nextchapter-design-tokens
+
+Shared Tailwind CSS design tokens for NextChapter. Single source of truth for colours, typography, spacing, and radii — consumed by both the Rails web app and the React Native mobile app.
+
+## Token coverage
+
+- Colours (`--color-*`)
+- Font families (`--font-*`)
+- Border radii (`--radius-*`)
+- Spacing scale (`--spacing-*`)
+
+Full token definitions and design rationale are documented in `docs/DESIGN.md` in the [nextchapter](https://github.com/stevebutler2210/nextchapter) repository.
+
+## Installation
+
+This package is published to GitHub Packages. You will need a GitHub personal access token (PAT) scoped to `read:packages`.
+
+Create or update `.npmrc` in the root of your consuming project:
+
+```plaintext
+@stevebutler2210:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=YOUR_GITHUB_PAT
+```
+
+Then install:
+
+```bash
+npm install @stevebutler2210/nextchapter-design-tokens
+```
+
+## Usage
+
+### Rails (Tailwind CSS v4)
+
+In your main CSS file, after `@import "tailwindcss"`:
+
+```css
+@import "tailwindcss";
+@import "@stevebutler2210/nextchapter-design-tokens";
+```
+
+### React Native (NativeWind v5)
+
+In `global.css`, after the standard NativeWind imports:
+
+```css
+@import "tailwindcss/theme.css" layer(theme);
+@import "tailwindcss/preflight.css" layer(base);
+@import "tailwindcss/utilities.css";
+@import "nativewind/theme";
+@import "@stevebutler2210/nextchapter-design-tokens";
+```
+
+## Versioning
+
+This package follows semantic versioning. Any change to a token value or name is a breaking change and warrants a major version bump.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@stevebutler2210/nextchapter-design-tokens",
+  "version": "0.1.0",
+  "description": "Shared Tailwind CSS design tokens for NextChapter",
+  "main": "tokens.css",
+  "exports": {
+    ".": "./tokens.css"
+  },
+  "files": [
+    "tokens.css"
+  ],
+  "keywords": [
+    "design-tokens",
+    "tailwind",
+    "nativewind",
+    "nextchapter"
+  ],
+  "license": "UNLICENSED",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/tokens.css
+++ b/tokens.css
@@ -1,0 +1,89 @@
+/* @stevebutler2210/nextchapter-design-tokens
+   Single source of truth for NextChapter design tokens.
+   Consumed by the Rails app (Tailwind v4 @theme) and the
+   mobile app (NativeWind v5 global.css @import).
+   Do not edit token values here without updating docs/DESIGN.md first. */
+
+@theme {
+  /* Colours */
+  --color-surface: #fcf9f5;
+  --color-surface-container-lowest: #ffffff;
+  --color-surface-container-low: #f7f4f0;
+  --color-surface-container: #f0ede9;
+  --color-surface-container-high: #e5e2de;
+  --color-surface-container-highest: #dbd8d4;
+  --color-surface-variant: #e1ddd8;
+  --color-on-surface: #1c1c1a;
+  --color-primary: #89453a;
+  --color-primary-container: #f4ebe9;
+  --color-on-primary: #ffffff;
+  --color-tertiary: #7a826e;
+  --color-tertiary-container: #eff1ed;
+  --color-outline: #85827e;
+  --color-outline-variant: #d1cfcc;
+
+  /* Typography */
+  --font-newsreader: "Newsreader", Georgia, serif;
+  --font-work-sans: "Work Sans", system-ui, sans-serif;
+
+  /* Radii */
+  --radius-sm: 2px;
+  --radius: 4px;
+
+  /* Spacing */
+  --spacing-1: 4px;
+  --spacing-2: 8px;
+  --spacing-3: 12px;
+  --spacing-4: 16px;
+  --spacing-5: 20px;
+  --spacing-6: 24px;
+  --spacing-7: 28px;
+  --spacing-8: 32px;
+  --spacing-9: 36px;
+  --spacing-10: 40px;
+  --spacing-11: 44px;
+  --spacing-12: 48px;
+  --spacing-13: 52px;
+  --spacing-14: 56px;
+  --spacing-15: 60px;
+  --spacing-16: 64px;
+}
+
+/* :root block mirrors @theme values for NativeWind's CSS variable runtime resolver */
+:root {
+  --color-surface: #fcf9f5;
+  --color-surface-container-lowest: #ffffff;
+  --color-surface-container-low: #f7f4f0;
+  --color-surface-container: #f0ede9;
+  --color-surface-container-high: #e5e2de;
+  --color-surface-container-highest: #dbd8d4;
+  --color-surface-variant: #e1ddd8;
+  --color-on-surface: #1c1c1a;
+  --color-primary: #89453a;
+  --color-primary-container: #f4ebe9;
+  --color-on-primary: #ffffff;
+  --color-tertiary: #7a826e;
+  --color-tertiary-container: #eff1ed;
+  --color-outline: #85827e;
+  --color-outline-variant: #d1cfcc;
+  --font-newsreader: "Newsreader", Georgia, serif;
+  --font-work-sans: "Work Sans", system-ui, sans-serif;
+  --radius-sm: 2px;
+  --radius: 4px;
+  --spacing-1: 4px;
+  --spacing-2: 8px;
+  --spacing-3: 12px;
+  --spacing-4: 16px;
+  --spacing-5: 20px;
+  --spacing-6: 24px;
+  --spacing-7: 28px;
+  --spacing-8: 32px;
+  --spacing-9: 36px;
+  --spacing-10: 40px;
+  --spacing-11: 44px;
+  --spacing-12: 48px;
+  --spacing-13: 52px;
+  --spacing-14: 56px;
+  --spacing-15: 60px;
+  --spacing-16: 64px;
+}


### PR DESCRIPTION
Exports NextChapter design tokens as a private GitHub Packages npm package. Covers colours, typography, radii, and spacing. Consumed via @import in both the Rails (Tailwind v4) and React Native (NativeWind v5) apps.

Closes #2 